### PR TITLE
changed AWS keys to be taken from the environment variables and not from terraform variables

### DIFF
--- a/redash/v5.0.2/aws/providers.tf
+++ b/redash/v5.0.2/aws/providers.tf
@@ -1,8 +1,5 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  token = "${var.aws_session_token}"
-  region = "${var.aws_default_region}"
+  region = var.aws_default_region
 }
 
 # Using these data sources allows the configuration to be

--- a/redash/v5.0.2/aws/variables.tf
+++ b/redash/v5.0.2/aws/variables.tf
@@ -1,4 +1,1 @@
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_session_token" {}
-variable "aws_default_region" {default = "us-east-1"}
+variable "aws_default_region" { default = "us-east-1"}


### PR DESCRIPTION
Now in order to make this configuration work you will need to export the following environment variables:
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_SESSION_TOKEN

See [terraform documentation](https://www.terraform.io/docs/providers/aws/index.html#environment-variables)
 