### PR TITLE
Fix tags block

### DIFF
--- a/redash/v5.0.2/aws/ec2.tf
+++ b/redash/v5.0.2/aws/ec2.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "redash-instance" {
   key_name = "${aws_key_pair.redash-key-pair.key_name}"
 
   tags {
-    Name = "redash-instance",
+    Name = "redash-instance"
     CreatedBy = "env0"
     Env0 = "${random_uuid.uuid.result}"
   }


### PR DESCRIPTION
Terraform 11 is forgiving, but it seems HCL1.0 shouldn't in fact allow commas as delimiter in block attributes, but rather new line: 
```
Unexpected comma after argument; Argument definitions must be separated by newlines, not commas. An argument definition must end with a newline.]
```

For more details see https://github.com/env0/terratag/issues/9